### PR TITLE
Feature/Projects hero

### DIFF
--- a/components/CategoryLink.js
+++ b/components/CategoryLink.js
@@ -1,17 +1,17 @@
+import React from 'react';
 import { getVariation } from '../utils/global-functions';
 
-export default function CategoryLink({
+export default React.forwardRef(({
   Component = 'div',
   children,
   highlight = false,
   ...props
-}) {
-  return (
-    <Component
-      className={getVariation('category-link', highlight ? 'highlighted' : 'none')}
-      {...props}
-    >
-      {children}
-    </Component>
-  );
-}
+}, ref) => (
+  <Component
+    className={getVariation('category-link', highlight ? 'highlighted' : 'none')}
+    {...props}
+    ref={ref}
+  >
+    {children}
+  </Component>
+));

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,12 +1,21 @@
 import Link from 'next/link';
 
-export default function Hero({ fields }) {
+export default function Hero({
+  fields,
+  baseUrl = '',
+  linksToBlank = true,
+  hideLine = false,
+}) {
   const {
     title: { fields: { title: sectionTitle } },
     description,
     heroBackground: { fields: { file: { url: img } } },
-    cta: { fields: { link: ctaLink, label: ctaLabel } },
-    socialNetworksSection,
+    cta: {
+      fields: {
+        link: ctaLink = null, label: ctaLabel = null,
+      } = {},
+    } = {},
+    socialNetworksSection = [],
   } = fields;
 
   return (
@@ -18,26 +27,51 @@ export default function Hero({ fields }) {
       <div className="hero-content">
         <h1 className="hero-title">{sectionTitle}</h1>
         <p className="hero-description">{description}</p>
+        {!!ctaLink && (
         <Link href={`/${ctaLink}`}>
           <p className="button-main hero-button">{ctaLabel}</p>
         </Link>
+        )}
 
-        <div className="hero-media-wrapper">
-          <div className="hero-line" />
-          {socialNetworksSection.map(({
-            fields: { title, icon, link },
-            sys: { id },
-          }) => (
-            <a href={link} target="_blank" rel="noreferrer" key={id}>
-              <img
-                key={title}
-                src={icon.fields.file.url}
-                alt={title}
-                className="hero-media"
-              />
-            </a>
-          ))}
-        </div>
+        {socialNetworksSection.length > 0
+          && (
+          <div className="hero-media-wrapper">
+            {!hideLine && <div className="hero-line" />}
+            {socialNetworksSection.map(({
+              fields: { title, icon, link },
+              sys: { id },
+            }) => (
+              linksToBlank
+                ? (
+                  <a href={`${baseUrl}${link}`} target="_blank" rel="noreferrer" key={id}>
+                    <img
+                      key={title}
+                      src={icon.fields.file.url}
+                      alt={title}
+                      className="hero-media"
+                    />
+                  </a>
+                )
+                : (
+                  <Link
+                    href={`${baseUrl}${link}`}
+                    passHref
+                    key={id}
+                    shallow
+                  >
+                    <a href="/">
+                      <img
+                        key={title}
+                        src={icon.fields.file.url}
+                        alt={title}
+                        className="hero-media"
+                      />
+                    </a>
+                  </Link>
+                )
+            ))}
+          </div>
+          )}
       </div>
 
       <img src="/icons/arrow-down.svg" className="hero-arrow" alt="" />

--- a/components/Project.js
+++ b/components/Project.js
@@ -23,7 +23,7 @@ export default function Project({
         data={{
           title: projectTitle,
           content: projectBrief,
-          link: slug,
+          link: `proyectos/detalle/${slug}`,
           label: 'Más información',
           url,
           imgTitle,

--- a/pages/proyectos/[categoryId].js
+++ b/pages/proyectos/[categoryId].js
@@ -1,13 +1,17 @@
 import getPageData from '../../utils/api';
+import { MASTERPAGE, PROJECTS } from '../../utils/constants';
 
 export const getServerSideProps = async () => {
   try {
-    const pageData = await getPageData('proyectos');
+    const pageData = await getPageData(PROJECTS);
+    const masterPageProps = await getPageData('', MASTERPAGE);
 
     return {
       props: {
         data: pageData,
         components: pageData.fields.components,
+        masterPageProps: masterPageProps.fields,
+
       },
     };
   } catch (e) {

--- a/pages/proyectos/index.js
+++ b/pages/proyectos/index.js
@@ -4,6 +4,7 @@ import getPageData from '../../utils/api';
 import ProjectWrapper from '../../components/ProjectWrapper';
 import Projects from '../../components/Projects';
 import { ALL_PROJECTS_CATEGORY_FILTER, PROJECTS, MASTERPAGE } from '../../utils/constants';
+import Hero from '../../components/Hero';
 
 export const getServerSideProps = async () => {
   try {
@@ -39,9 +40,10 @@ function getCategoryProjects(projects, category) {
 export default function ProjectsPage({ components }) {
   const { query } = useRouter();
   const { categoryId } = query;
-  const [, , { fields: categories },
+  const [, { fields: hero }, { fields: categories },
     { fields: { project: projects } }] = components;
   const [projectsToDisplay, setProjectsToDisplay] = useState(projects);
+  const heroBaseUrl = '/proyectos/';
 
   useEffect(() => {
     setProjectsToDisplay(getCategoryProjects(projects, categoryId));
@@ -49,7 +51,12 @@ export default function ProjectsPage({ components }) {
 
   return (
     <div className="projects-page">
-      <div><h1>HERO</h1></div>
+      <Hero
+        fields={hero}
+        baseUrl={heroBaseUrl}
+        linksToBlank={false}
+        hideLine
+      />
       <ProjectWrapper
         currCategory={categoryId}
         categories={categories}

--- a/styles/components/hero.scss
+++ b/styles/components/hero.scss
@@ -1,4 +1,5 @@
 .hero {
+  $min-width: 1440px;
   $min-height: 575px;
   $max-screen-size: 1440px;
 
@@ -25,6 +26,7 @@
   &-background {
     position: absolute;
     left: 50%;
+    min-width: $min-width;
     transform: translateX(-50%);
     top: 0;
     z-index: -1;
@@ -61,6 +63,7 @@
   &-title {
     @include heading-1();
 
+    width: 80%;
     color: $ayp-grey-0;
   }
 
@@ -82,7 +85,7 @@
 
   &-media {
     margin-left: 24px;
-    filter: invert(1);
+    max-width: 70px;
   }
 
   &-line {


### PR DESCRIPTION
## Changes

- Added options to customize Hero (Show/Hide line, use <a> or next's <Link>)
- Fixed some styling issues on hero
- Placed hero in projects page
- Fixed link in Project so that it leads to "/proyectos/detalle/[id]"

## Observations 

- Links in project's hero are in different order from the categories below
- Url from "Arte y cultura" on hero is "arte-cultura", this differs from the one obtained in the projects list which is "arte-y-cultura". This can cause problems filtering projects and highlighting the selected category
- Social media links from home's hero should be white

![image](https://user-images.githubusercontent.com/43077180/133664628-e473f076-9e6d-4355-a067-2407bfe98430.png)
