### PR TITLE
enhancement/style-fixions

### DIFF
--- a/components/Collaborate.js
+++ b/components/Collaborate.js
@@ -17,7 +17,7 @@ export default function Collaborate({
   return (
     <section>
       <BigImageLayout
-        variation={['reverse', 'vertical-margin']}
+        variation={['reverse', 'on-context']}
         contentType="rich"
         data={{
           title,

--- a/pages/apoyanos.js
+++ b/pages/apoyanos.js
@@ -30,14 +30,17 @@ export default function SupportUsPage({ components }) {
       <Hero
         fields={hero}
       />
-      <BigImageLayout
-        contentType="rich"
-        data={{
-          url: howTo.sectionImage.fields.file.url,
-          imgTitle: howTo.sectionImage.fields.title,
-          ...howTo,
-        }}
-      />
+      <section>
+        <BigImageLayout
+          contentType="rich"
+          variation={['on-context']}
+          data={{
+            url: howTo.sectionImage.fields.file.url,
+            imgTitle: howTo.sectionImage.fields.title,
+            ...howTo,
+          }}
+        />
+      </section>
       <Collaborate
         fields={collaborate}
       />

--- a/styles/common/header.scss
+++ b/styles/common/header.scss
@@ -63,6 +63,7 @@
           margin: 0;
           line-height: initial;
           border-bottom: 3px solid transparent;
+          padding-bottom: 5px;
 
           &::before {
             display: none;
@@ -97,6 +98,7 @@
 
     .button-header {
       margin-left: 41px;
+      text-align: center;
     }
 
     &__icon {
@@ -198,7 +200,7 @@
     &.active {
       height: 100%;
       position: fixed;
-      width: 100%;
+      width: 85%;
 
       .navigation__list {
         display: block;

--- a/styles/components/hero.scss
+++ b/styles/components/hero.scss
@@ -117,10 +117,13 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    bottom: 64px;
+    bottom: 35px;
+  }
+}
 
-    @media (min-width: $bp-sm) {
-      display: none;
-    }
+.home .hero-media-wrapper {
+  a > img {
+    width: 24px;
+    height: 24px;
   }
 }

--- a/styles/components/last-projects.scss
+++ b/styles/components/last-projects.scss
@@ -70,6 +70,7 @@
     }
 
     &__body {
+      color: $ayp-grey-70;
       font-family: $main-font;
       font-size: 18px;
       line-height: 24px;

--- a/styles/components/members-grid.scss
+++ b/styles/components/members-grid.scss
@@ -31,6 +31,10 @@
       grid-auto-rows: auto;
     }
 
+    @media (min-width: $bp-lg) {
+      grid-gap: 50px;
+    }
+
     & > * {
       grid-column-end: span 3;
     }

--- a/styles/components/paginator.scss
+++ b/styles/components/paginator.scss
@@ -14,6 +14,7 @@
 
   @media (min-width: $bp-md) {
     margin-top: 65px;
+    margin-bottom: 270px;
   }
 
   &__button {

--- a/styles/components/testimony.scss
+++ b/styles/components/testimony.scss
@@ -23,6 +23,10 @@
     }
   }
 
+  &__info {
+    line-height: 32px;
+  }
+
   &__info-mobile {
     margin-left: 25px;
 
@@ -55,12 +59,14 @@
   &__title {
     @include hero-body();
 
+    line-height: 20px;
     text-transform: capitalize;
   }
 
   &__subtitle {
     @include eyebrow();
 
+    font-weight: 400;
     margin-bottom: 15px;
   }
 }

--- a/styles/layout/big-image-layout.scss
+++ b/styles/layout/big-image-layout.scss
@@ -85,7 +85,11 @@
     h2 {
       @include heading-1();
 
-      margin-bottom: 50px;
+      margin-bottom: 30px;
+
+      @media (min-width: $bp-md) {
+        margin-bottom: 50px;
+      }
     }
   }
 
@@ -200,9 +204,5 @@
 
   &--reverse {
     @include reverse();
-  }
-
-  &--vertical-margin {
-    margin: 156px auto;
   }
 }

--- a/styles/layout/projects.scss
+++ b/styles/layout/projects.scss
@@ -1,8 +1,20 @@
 .project {
-  margin: 95px auto;
+  margin: 50px auto;
+
+  @media (min-width: $bp-md) {
+    margin: 95px auto;
+  }
 
   &:last-child {
     margin-bottom: 0;
+  }
+
+  &:first-child {
+    margin-top: 20px;
+
+    @media (min-width: $bp-md) {
+      margin-top: 70px;
+    }
   }
 
   &--empty {


### PR DESCRIPTION
**On Mobile**

Home 
> LastProjects color changed to gray70
> The icons on hero have now their size specified

Global
> Modal Mobile Hamburger Menu - Apóyanos button is now centered
> Modal Mobile Hamburger Menu - The modal takes only the 85% of the width instead of the 100%
> Hero down arrow now is a little more below their last position 
> The title margin of BigImageLayout at mobile is now at 30 at mobile

Projects
> The first project's margin is in 20px on mobile instead of 95px
> Project title have now a margin of 20px instead of 50px
> There are now margins of 100px between projects instead of 145px

Corporation
> Members grid member have now a 20px line height and 10px of margin bottom

Apoyanos
> On "Como apoyar a la corporación" and in "Formas de Colaborar" now the image is first than the text
> "Como apoyar a la corporación" now is a section instead of a div
> The line-height of the name on "Dicen lo que nos conocen" is now 20px and the text of the subtitle has now 400 of font-weight.
> The text on "Dicen los que nos conocen" now have a line-height of 32px.

**On Desktop**

Global
> Header line for element selected is now more separated from text (5px)

Projects
> The first margin now at 70px instead of 95px
> The pagination margin bottom is now 100px higher.

Corporation
> Members Grid column gap is now at 50px
