### PR TITLE
Fix styles according to Figma prototype

### DIFF
--- a/styles/common/footer.scss
+++ b/styles/common/footer.scss
@@ -3,7 +3,7 @@
   padding: 44px 0;
 
   @media (min-width: $bp-md) {
-    padding: 92px 0 44px 0;
+    padding: 75px 0 115px 0;
   }
 
   .footer-nav {
@@ -87,7 +87,8 @@
           max-width: 100%;
           width: 100%;
           text-align: center;
-          margin-top: 31px;
+          margin-bottom: 25px;
+          margin-top: 25px;
           flex: 0 0 100%;
 
           @media (min-width: $bp-md) {
@@ -130,8 +131,6 @@
 
     &__social-media {
       flex: 0 0 100%;
-      margin-bottom: 45px;
-      margin-top: 24px;
 
       @media (min-width: $bp-md) {
         flex: 0 0 58.33%;

--- a/styles/common/header.scss
+++ b/styles/common/header.scss
@@ -60,7 +60,7 @@
         }
 
         li {
-          margin: 0;
+          margin: 0 10px;
           line-height: initial;
           border-bottom: 3px solid transparent;
           padding-bottom: 5px;
@@ -70,7 +70,7 @@
           }
 
           .navigation__item {
-            font-size: 16px;
+            font-size: 14px;
             font-family: $main-font;
             font-weight: 500;
             text-transform: uppercase;
@@ -97,8 +97,9 @@
     }
 
     .button-header {
-      margin-left: 41px;
+      margin-left: 30px;
       text-align: center;
+      font-weight: 700;
     }
 
     &__icon {

--- a/styles/components/hero.scss
+++ b/styles/components/hero.scss
@@ -73,15 +73,21 @@
   &-title {
     @include heading-1();
 
-    width: 80%;
+    width: 85%;
     color: $ayp-grey-0;
+    line-height: 40px;
+
+    @media (min-width: $bp-md) {
+      font-size: 52px;
+      line-height: 62px;
+    }
   }
 
   &-description {
     @include hero-body();
 
     color: $ayp-grey-0;
-    margin: 24px 0;
+    margin: 10px 0;
   }
 
   &-media-wrapper {
@@ -89,7 +95,8 @@
 
     @media (min-width: $bp-sm) {
       display: flex;
-      margin-top: 64px;
+      margin-top: 40px;
+      align-items: center;
     }
   }
 
@@ -99,8 +106,6 @@
   }
 
   &-line {
-    position: relative;
-    top: 17px;
     width: 100px;
     height: 3px;
     background-color: $ayp-grey-0;
@@ -108,6 +113,7 @@
 
   &-button {
     width: fit-content;
+    margin-top: 30px;
   }
 
   &-arrow {
@@ -122,5 +128,9 @@
   a > img {
     width: 24px;
     height: 24px;
+  }
+
+  @media (min-width: $bp-sm) {
+    margin-top: 70px;
   }
 }

--- a/styles/layout/big-image-layout.scss
+++ b/styles/layout/big-image-layout.scss
@@ -50,7 +50,7 @@
       margin-top: 90px;
 
       @media (min-width: $bp-sm) {
-        margin-top: 200px;
+        margin-top: 115px;
       }
     }
 
@@ -181,6 +181,10 @@
           margin-bottom: 0;
         }
       }
+    }
+
+    .big-image-layout__content p {
+      max-width: initial;
     }
   }
 


### PR DESCRIPTION
## Navbar

- Puse espacios entre los links para que la linea de abajo no se junte
- Hice la letra más pequeña (14px)
- El botón de apóyanos tiene menos margin a la izquierda

## Hero

- Se cambió el tamaño de letra y altura de línea del título
- Se ajustó los espacios verticales entre los elementos
- Se centró la línea junto a los íconos de redes sociales

## Sección join us

- Se ajustó el padding-top

## Footer

- Se ajustó el espacio entre el borde superior e inferior y el contenido
- Se centró verticalmente el texto de copyright con los íconos de redes sociales

## Página de proyectos

- Se ajustó el max-width de los textos en la variación big-image-layout--project